### PR TITLE
修正在 Safari 用選單列或快速鍵切到全一輸入法，選單列馬上跳回 ABC 問題, 每個沙盒 App 在 DARWIN_USER_CAC…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@
 
 也可手動執行新版 DMG 內的同一個安裝程式。安裝程式會先備份舊版，完成後重新載入輸入法；安裝失敗時嘗試還原。個人詞頻與偏好設定會保留。
 
+若在某個 App（例如 Safari）切換到全一輸入法後立刻跳回 ABC，通常是該 App 保存的輸入法清單快取仍停留在安裝前。安裝程式完成時會清除這類過期快取，並列出需要重新開啟的 App；重新開啟後即可切換。舊版安裝程式沒有這一步，可先結束該 App，在「終端機」執行下列指令後重新開啟（以 Safari 為例，其他 App 請將 `com.apple.Safari` 換成該 App 的 bundle ID）：
+
+```sh
+rm -f "$(getconf DARWIN_USER_CACHE_DIR)com.apple.Safari/com.apple.IntlDataCache.le"*
+```
+
 ## 基本操作
 
 以下按鍵作用於尚未送出的組字內容。

--- a/doc/README.md
+++ b/doc/README.md
@@ -100,6 +100,8 @@ CLI 模擬器的左右鍵會先提交組字，與原生 SessionCtl 在組字內�
 
 ## 發布與安裝程式
 
-發布者本機的 `pack.command` 不隨 GitHub 原始碼提供；此工具預設從最新原始碼建置 release，依序簽署、公證輸入法、安裝程式及 DMG，最後產生 SHA-256 校驗檔。安裝程式位於 `scripts/installer/Installer.swift`，只更新目前使用者的輸入法，並處理舊版備份、失敗還原與服務重新載入。
+發布者本機的 `pack.command` 不隨 GitHub 原始碼提供；此工具預設從最新原始碼建置 release，依序簽署、公證輸入法、安裝程式及 DMG，最後產生 SHA-256 校驗檔。安裝程式位於 `scripts/installer/Installer.swift`，只更新目前使用者的輸入法，並處理舊版備份、失敗還原、過期輸入來源快取清除與服務重新載入。
+
+沙盒 App 會在 `DARWIN_USER_CACHE_DIR/<bundle id>/` 各自保存輸入來源快取（`com.apple.IntlDataCache.le*`）。快取若建立於輸入法安裝或搬移之前，該 App 會判定輸入法無法解析，切換後立即跳回 ABC。安裝程式與本機部署腳本（`reload-IME.command`、`build.sh --deploy`、`build-dev.command`、`build-release-notarize.command`）在註冊輸入法後，會清除未記錄目前安裝路徑的快取，並列出需要重新開啟的前景 App。shell 端邏輯位於 `scripts/ime_cache_common.sh`，`clear_stale_input_source_caches` 支援 `--dry-run`；安裝程式可用 `--list-stale-input-source-caches` 只列出、不刪除。原因與排查方式請參考 [踩坑紀錄](踩坑紀錄.md) 第 37 條。
 
 封裝時由 `Resources/Bopomofo.tiff` 產生 ICNS，供安裝程式與 DMG 磁碟使用。所有圖示與資源變更均在簽章前完成。完整參數與操作請參考 [部署說明](DEPLOY.md)。

--- a/doc/踩坑紀錄.md
+++ b/doc/踩坑紀錄.md
@@ -510,3 +510,17 @@ state -> predict -> preview、candidates、commit
   - 在 `handle(_:, client:)` 的最外層計時
   - 只統計真的有字元內容的 keydown
 - 這樣才能把 `readingWalker`、`rankCandidates`、`mixed merge` 之外的外層成本一起算進來。
+
+**37. 特定 App（如 Safari）選了全一輸入法卻立刻跳回 ABC：沙盒 App 的輸入來源快取過期**
+
+- 症狀：
+  - 在 Safari 用選單列或快速鍵切到全一輸入法，選單列馬上跳回 ABC；同一時間在其他 App 可以正常使用。
+  - 重開 Safari、重新簽章、改 Info.plist 都無效；輸入法程序也完全沒有收到 `activateServer`。
+- 根因：
+  - 每個沙盒 App 會在 `$(getconf DARWIN_USER_CACHE_DIR)<bundle id>/` 保存自己的輸入來源清單快取：`com.apple.IntlDataCache.le` 與 `com.apple.IntlDataCache.le.kbdx`。
+  - 這份快取若建立於輸入法安裝或搬移之前，不會自動更新。
+  - 切換輸入法時，系統把選擇送給目前的鍵盤焦點 App；該 App 在自己的快取裡找不到全一，HIToolbox 記錄 `** Message from TIM selects unresolvable input source` 後直接放棄，不會連線輸入法。
+- 修正：
+  - 結束該 App → 刪除上述兩個快取檔 → 重新開啟，App 會重建快取。
+  - `reload-IME.command`、`build.sh --deploy`、`build-dev.command`、`build-release-notarize.command` 與安裝程式，已在註冊輸入法後自動清除「未記錄目前安裝路徑」的快取（`scripts/ime_cache_common.sh`、`scripts/installer/Installer.swift`）；正在執行的 App 仍需重新開啟。
+  - 只想列出不刪除：shell 端用 `clear_stale_input_source_caches <app 路徑> --dry-run`，安裝程式用 `--list-stale-input-source-caches`。

--- a/scripts/build-dev.command
+++ b/scripts/build-dev.command
@@ -17,6 +17,8 @@ ditto "$APP" "$INSTALL"
 
 echo "Refreshing registration..."
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$INSTALL"
+source "$ROOT/scripts/ime_cache_common.sh"
+clear_stale_input_source_caches "$INSTALL"
 killall UnifyIME >/dev/null 2>&1 || true
 killall "快捷中文測試" >/dev/null 2>&1 || true
 killall TextInputMenuAgent >/dev/null 2>&1 || true

--- a/scripts/build-release-notarize.command
+++ b/scripts/build-release-notarize.command
@@ -32,6 +32,8 @@ xcrun stapler staple "$INSTALL"
 
 echo "Refreshing registration..."
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$INSTALL"
+source "$WORKSPACE_ROOT/scripts/ime_cache_common.sh"
+clear_stale_input_source_caches "$INSTALL"
 killall UnifyIME >/dev/null 2>&1 || true
 killall TextInputMenuAgent >/dev/null 2>&1 || true
 killall cfprefsd >/dev/null 2>&1 || true

--- a/scripts/ime_cache_common.sh
+++ b/scripts/ime_cache_common.sh
@@ -1,0 +1,43 @@
+#!/bin/zsh
+# 共用輸入法快取清理：清除沙盒 App 各自保存的過期輸入來源快取。
+# macOS 會在 DARWIN_USER_CACHE_DIR/<bundle id>/ 為每個沙盒 App 另存 com.apple.IntlDataCache.le(.kbdx)。
+# 快取若建立於輸入法安裝或搬移之前，該 App 會回報 "unresolvable input source"，選了輸入法也會跳回 ABC。
+# 用法：clear_stale_input_source_caches <已安裝的 .app 路徑> [--dry-run]
+clear_stale_input_source_caches() {
+  local install_dir="${1:A}"
+  local dry_run="${2:-}"
+  local cache_root
+  cache_root="$(getconf DARWIN_USER_CACHE_DIR 2>/dev/null)" || return 0
+  cache_root="${cache_root%/}"
+  [[ -d "$cache_root" ]] || return 0
+
+  local kbdx app_cache_dir bundle_id asn
+  local -a cleared running
+  # 只看各 App 子目錄；最上層的共用快取由系統在註冊輸入法時重建。
+  for kbdx in "$cache_root"/*/com.apple.IntlDataCache.le.kbdx(N); do
+    if LC_ALL=C grep -aqF -- "$install_dir" "$kbdx"; then
+      continue
+    fi
+    app_cache_dir="${kbdx:h}"
+    bundle_id="${app_cache_dir:t}"
+    if [[ "$dry_run" != "--dry-run" ]]; then
+      /bin/rm -f -- "$app_cache_dir/com.apple.IntlDataCache.le" "$app_cache_dir/com.apple.IntlDataCache.le.kbdx"
+    fi
+    cleared+=("$bundle_id")
+    # 只提示有視窗的前景 App；延伸功能與背景代理程式不需手動重開。
+    asn="$(lsappinfo find bundleid="$bundle_id" 2>/dev/null)"
+    asn="${asn%% *}"
+    if [[ -n "$asn" ]] && lsappinfo info -only ApplicationType "$asn" 2>/dev/null | grep -q '"Foreground"'; then
+      running+=("$bundle_id")
+    fi
+  done
+
+  local action="已清除"
+  [[ "$dry_run" == "--dry-run" ]] && action="將清除（dry-run）"
+  print "${action}過期輸入法快取：${#cleared} 個 App"
+  if (( ${#running} > 0 )); then
+    print "以下 App 正在執行，需重新開啟才會看到新的輸入法："
+    print -l -- "  "${^running}
+  fi
+  return 0
+}

--- a/scripts/reload-IME.command
+++ b/scripts/reload-IME.command
@@ -1,7 +1,10 @@
 #!/bin/zsh
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL="$HOME/Library/Input Methods/全一輸入法.app"
+
+source "$SCRIPT_DIR/ime_cache_common.sh"
 
 echo "Reloading UnifyIME..."
 
@@ -11,6 +14,7 @@ killall TextInputMenuAgent >/dev/null 2>&1 || true
 killall cfprefsd >/dev/null 2>&1 || true
 
 /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f "$INSTALL" >/dev/null 2>&1 || true
+clear_stale_input_source_caches "$INSTALL"
 
 open -gja "$INSTALL"
 sleep 1


### PR DESCRIPTION
…HE_DIR/<bundle id>/ 各存一份輸入法清單快取，舊快取裡找不到全一，系統就記錄 unresolvable input source 並放棄切換。